### PR TITLE
Bugfix for issue where if the server responded with non-JSON ``JSONDe…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ Release History
 0.1.2 (unreleased)
 ++++++++++++++++++
 
-- Nothing changed yet.
+- Bugfix for issue where if the server responded with non-JSON ``JSONDecodeError`` would raise, now raises ``BrickFTPError``.
 
 
 0.1.1 (2018-04-19)


### PR DESCRIPTION
- Bugfix for issue where if the server responded with non-JSON ``JSONDecodeError`` would raise, now raises ``BrickFTPError``.
- Also if there is a connection error, raise BrickFTPError instead of the requests library exception.